### PR TITLE
Add league-rpc-auto-launcher startup script for Lutris / League launchers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Installation](#installation)
   - [Source Code](#source-code)
   - [Pre-built Package](#pre-built-package)
+  - [League RPC Auto Launcher Script (Lutris example)](#league-rpc-auto-launcher-script)
 - [Features](#features)
 - [Command Line Arguments](#command-line-arguments)
 - [FAQ](#faq)
@@ -53,6 +54,9 @@ Arena games are now supported as of v0.0.7
 ![Arena-example](https://github.com/Its-Haze/league-rpc-linux/blob/master/assets/league-rpc-arena-example.png?raw=true)
 
 ## Installation
+- Are you using Lutris? Then please take a look at [League RPC Auto Launcher Script (Lutris example)](#league-rpc-auto-launcher-script)
+
+
 
 ### Source Code
 
@@ -125,6 +129,57 @@ Alternatively, install the executable Python package directly from the [releases
    ```
 
 4. Yup.. that's pretty much it! Enjoy
+
+### League RPC Auto Launcher Script
+
+The `league-rpc-auto-launcher.sh` script enhances your League of Legends experience on Linux by automatically updating and launching the League of Legends Discord Rich Presence alongside the game.
+
+This script can be ran as a standalone, but it is recommended to be put as a Pre-launch script for launchers such as Lutris.
+
+
+Before running any bash script from strangers on the internet.. Please read and try to understand what it does.
+Short summary:
+
+- It will download the latest version of `league_rpc_linux`, and store it in `$HOME/.league-rpc-linux/`
+- It will then execute this program.
+- If you don't want it to always fetch the latest version of `league_rpc_linux`, then change the variable to `AUTO_INSTALL` to `false` like this `AUTO_INSTALL=false` (default is true). This expects an already `league_rpc_linux` file to be present in `$HOME/.league-rpc-linux/`.. otherwise an error will occur, You can see and follow all logs in this file: `$HOME/.league-rpc-linux/update_log.txt`
+
+Follow these steps to set it up:
+
+1. **Download the Script**:
+
+   Download the `league-rpc-auto-launcher.sh` script
+
+   ```bash
+   wget https://raw.githubusercontent.com/Its-Haze/league-rpc-linux/master/league-rpc-auto-launcher.sh -O league-rpc-auto-launcher.sh
+   ```
+
+2. **Make the Script Executable**:
+
+   Once downloaded, you need to make the script executable. Open a terminal in the directory where the script is and run:
+
+   ```bash
+   chmod +x league-rpc-auto-launcher.sh
+   ```
+
+3. **Setting up in Lutris**:
+
+   To have the script run automatically when you start League of Legends via Lutris:
+
+   - Open Lutris and right-click on your League of Legends game.
+   - Select '`Configure`' from the context menu.
+   - In the configuration window, navigate to the '`System options`' tab.
+   - Make sure you have '`Advanced`' mode enabled.
+   - Scroll down to the '`Pre-launch script`' field.
+   - Enter the full path to the `league-rpc-auto-launcher.sh` script. For example:
+
+     ```
+     /home/yourusername/path/to/league-rpc-auto-launcher.sh
+     ```
+
+   - Click '`Save`' to apply the changes.
+
+Now, every time you start League of Legends through Lutris, the `league-rpc-auto-launcher.sh` script will ensure that the latest version of the Discord Rich Presence tool is installed and running, enhancing your gaming experience.
 
 ## Command Line Arguments
 

--- a/league-rpc-auto-launcher.sh
+++ b/league-rpc-auto-launcher.sh
@@ -68,7 +68,7 @@ fi
 # Check if the executable exists and is executable
 if [[ ! -x "$EXECUTABLE_PATH" ]]; then
     log_message "ERROR: Executable not found at $EXECUTABLE_PATH"
-    echo "If you want to quickly fetch the latest version, use --auto-install."
+    log_message "INFO: If you want to quickly fetch the latest version, use --auto-install."
     exit 1
 fi
 

--- a/league-rpc-auto-launcher.sh
+++ b/league-rpc-auto-launcher.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Configurations
+REPO="Its-Haze/league-rpc-linux"
+EXECUTABLE="league_rpc_linux"
+INSTALL_DIR="$HOME/.league-rpc-linux"
+EXECUTABLE_PATH="$INSTALL_DIR/$EXECUTABLE"
+LOG_FILE="$INSTALL_DIR/update_log.txt"
+AUTO_INSTALL=true # Set to (false) to not automatically install the latest version.
+
+# Function to log messages
+log_message() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Check for required programs: curl and grep
+for required_command in curl grep; do
+    if ! command -v $required_command &>/dev/null; then
+        log_message "Error: $required_command is not installed. Please install it and try again."
+        exit 1
+    fi
+done
+
+# Create the installation directory if it doesn't exist
+mkdir -p "$INSTALL_DIR"
+
+# Function to download and update the executable
+update_executable() {
+    log_message "Installing the executable..."
+    DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" |
+        grep "\"browser_download_url\": \".*$EXECUTABLE\"" |
+        cut -d '"' -f 4)
+
+    if [ -z "$DOWNLOAD_URL" ]; then
+        log_message "Failed to fetch release info."
+        exit 1
+    fi
+
+    log_message "Downloading from $DOWNLOAD_URL"
+    if curl -Ls "$DOWNLOAD_URL" -o "$EXECUTABLE_PATH"; then
+        chmod +x "$EXECUTABLE_PATH" || log_message "Failed to set executable permission."
+        log_message "Update successful."
+    else
+        log_message "Failed to download the executable."
+        exit 1
+    fi
+}
+
+# Process command-line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --auto-install)
+        AUTO_INSTALL=true
+        shift
+        ;;
+    *)
+        log_message "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+done
+
+# Perform auto-install if enabled
+if [[ "$AUTO_INSTALL" == true ]]; then
+    update_executable
+fi
+
+# Check if the executable exists and is executable
+if [[ ! -x "$EXECUTABLE_PATH" ]]; then
+    log_message "ERROR: Executable not found at $EXECUTABLE_PATH"
+    echo "If you want to quickly fetch the latest version, use --auto-install."
+    exit 1
+fi
+
+# Execute the program
+log_message "Executing the program..."
+exec "$EXECUTABLE_PATH" --wait-for-league -1 --wait-for-discord -1


### PR DESCRIPTION
Add shell script for downloading and executing league-rpc-linux automatically whenever league is started.

Add documentation with steps on how to set it up on Lutris.