### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools >= 61", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "league-rpc-linux"
+dynamic = ["version"]
+requires-python = ">= 3.10"
+dependencies = [
+    "pypresence >= 4.3.0",
+    "psutil >= 5.9.6",
+    "requests >= 2.31.0",
+    "nest_asyncio >= 1.5.8",
+    "lcu-driver >= 3.0.1"
+]
+
+[tool.setuptools.packages]
+find = {include = ["league_rpc_linux*"]}
+
+[tool.setuptools_scm]
+


### PR DESCRIPTION
This allows to easily package/install it

```
$ python -m build --wheel --no-isolation
$ python -m installer --destdir=$DEST dist/*.whl
```

There are many different build backends you can use but `setuptools` is well known "default" choice. You can switch to any other if you like them better etc.

See:
* https://packaging.python.org/en/latest/overview/
* https://packaging.python.org/en/latest/guides/writing-pyproject-toml
* https://build.pypa.io/en/stable/index.html