### PR TITLE
Do not gather base data about Arena, when the game mode is unavailable

### DIFF
--- a/league_rpc_linux/models/lcu/current_ranked_stats.py
+++ b/league_rpc_linux/models/lcu/current_ranked_stats.py
@@ -106,6 +106,11 @@ class ArenaStats:
         obj_map: dict[str, Any],
         ranked_type: str = "CHERRY",
     ) -> "ArenaStats":
+        if not obj_map[LolRankedRankedStats.QUEUE_MAP].get(ranked_type):
+            # Arena (CHERRY) is not always available to play.
+            # So when it's not, we make an early return of an instance with default values.
+            return cls()
+
         rated_tier = obj_map[LolRankedRankedStats.QUEUE_MAP][ranked_type][
             LolRankedRankedQueueStats.RATED_TIER
         ]

--- a/league_rpc_linux/models/rpc_updater.py
+++ b/league_rpc_linux/models/rpc_updater.py
@@ -251,7 +251,7 @@ class RPCUpdater:
             case GameFlowPhase.NONE | GameFlowPhase.WAITING_FOR_STATS | GameFlowPhase.PRE_END_OF_GAME | GameFlowPhase.END_OF_GAME:
                 self.in_client_rpc(rpc, module_data)
                 return
-            case GameFlowPhase.CHAMP_SELECT:
+            case GameFlowPhase.CHAMP_SELECT | GameFlowPhase.GAME_START:
                 # In Champ Select
                 self.in_champ_select_rpc(rpc, module_data)
                 return


### PR DESCRIPTION
When Arena is removed by riot.. we no longer get it in the queueMap. which causes a KeyError silently being caused, and stops the gather data function to properly continue.